### PR TITLE
Recognise cases when a zero attribute value is legitimate

### DIFF
--- a/src/HtmlObject/Traits/Helpers.php
+++ b/src/HtmlObject/Traits/Helpers.php
@@ -32,7 +32,7 @@ class Helpers
 
     foreach ((array) $attributes as $key => $value) {
       if (is_numeric($key)) $key = $value;
-      if (!$value and !in_array($key, array('value'))) continue;
+      if (!$value and !in_array($key, array('value','min','max'))) continue;
 
       $html[] = $key. '="' .static::entities($value). '"';
     }

--- a/tests/InputTest.php
+++ b/tests/InputTest.php
@@ -20,4 +20,29 @@ class InputTest extends HtmlObjectTests
     $this->assertEquals($input1, $input2);
     $this->assertHTML($matcher, $input2);
   }
+
+  public function testCanHaveZeroValue()
+  {
+    $input = Input::create('number', 'foo', 0)->render();
+    $matcher = '<input type="number" name="foo" value="0">';
+
+    $this->assertEquals($matcher, $input);
+  }
+
+  public function testCanHaveMinAndMax()
+  {
+    $input = Input::create('number', 'foo', 0)->min(50)->max(100)->render();
+    $matcher = '<input type="number" name="foo" min="50" max="100" value="0">';
+
+    $this->assertEquals($matcher, $input);
+  }
+
+  public function testMinCanBeZero()
+  {
+    $input = Input::create('number', 'foo', 0)->min(0)->max(100)->render();
+    $matcher = '<input type="number" name="foo" min="0" max="100" value="0">';
+
+    $this->assertEquals($matcher, $input);
+  }
+
 }


### PR DESCRIPTION
When tag attributes are parsed, any whose value isn't equivalent to "true" is discarded. However, as the value attribute can legitimately be zero or and empty string, it's white-listed.

However, it's not the only attribute that can legitimately have a zero value. Min and max for a number type input field  may be required to impose a zero bound on the field's input. So these have been added to the white-list, along with some associated tests.
