### PR TITLE
Treat attribtues set with boolean values as properties

### DIFF
--- a/src/Traits/Helpers.php
+++ b/src/Traits/Helpers.php
@@ -179,7 +179,13 @@ class Helpers
             }
 
             // Ignore some attributes
-            if (is_null($value) && !in_array($key, array('value', 'min', 'max'))) {
+            if ((is_null($value) || $value === false) && !in_array($key, array('value', 'min', 'max'))) {
+                continue;
+            }
+
+            // If set to boolean true, make the attribtue a property
+            if ($value === true) {
+                $html[] = $key;
                 continue;
             }
 

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -34,4 +34,15 @@ class HelpersTest extends HtmlObjectTestCase
 
         $this->assertEquals(' min="0" max="0" value="0"', $attributes);
     }
+
+    public function testCanTogglePropWithBooleanValues() {
+
+        $attributes = array('checked' => false);
+        $attributes = Helpers::parseAttributes($attributes);
+        $this->assertEquals('', $attributes);
+
+        $attributes = array('checked' => true);
+        $attributes = Helpers::parseAttributes($attributes);
+        $this->assertEquals(' checked', $attributes);
+    }
 }


### PR DESCRIPTION
When applying a checked state to a checkbox, it is convenient to set the `checked` attribute with a boolean like the [jQuery prop() API](http://api.jquery.com/prop/).  

```php
$bool = false; // Perhaps the property of a model
$el = Input::checkbox('foo', 'bar', ['checked' => $bool]);
```

#14 / #15 broke this by making `NULL` be the only wait to pass an attribute value that tells html-object not to add the attribute.  This PR makes it so setting an attribute value to `FALSE` will NOT create the attribute.  And setting it to `TRUE` will add the attribute as a property (no value).