### PR TITLE
Default dynamically set attribute to boolean true vs string 'true'.

### DIFF
--- a/src/Traits/Tag.php
+++ b/src/Traits/Tag.php
@@ -275,7 +275,7 @@ abstract class Tag extends TreeObject
         $method = str_replace('_', '-', $method);
 
         // Get value and set it
-        $value         = Helpers::arrayGet($parameters, 0, 'true');
+        $value         = Helpers::arrayGet($parameters, 0, true);
         $this->$method = $value;
 
         return $this;

--- a/tests/TagTest.php
+++ b/tests/TagTest.php
@@ -119,6 +119,14 @@ class TagTest extends HtmlObjectTestCase
         $this->assertHTML($matcher, $this->object);
     }
 
+    public function testCanDynamicallySetBooleanAttributesByDefault()
+    {
+        $this->object->required();
+
+        // cannot use assertHTML; it uses assertTag, which cannot find boolean attributes
+        $this->assertEquals('<p required>foo</p>', $this->object->render());
+    }
+
     public function testCanDynamicallyGetChild()
     {
         $two  = Element::p('foo');


### PR DESCRIPTION
When an attribute is dynamically set through the magic `__call()` method, but no parameter is supplied, the attribute is defaulted to the string `'true'`.  However, the `Helpers::parseAttributes()` method does a strict type comparison to the boolean `true` to determine boolean attributes. Due to this, when an attribute is set as `$tag->required()` or `$tag->checked()`, it is rendered as `required="true"` or `checked="true"`, instead of as an actual boolean attribute.

This pull request changes the default value for dynamically set attributes to a boolean `true` instead of the string `'true'`.

This also addresses issue formers/former#437.