### PR TITLE
Remove examples from repository auto-generated ZIP archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 /.travis.yml    export-ignore
 /phpunit.xml    export-ignore
 /tests          export-ignore
+/examples       export-ignore


### PR DESCRIPTION
People that install this library via composer don't need the examples, they just need the library itself.
This PR removes the sample directories and files from the repository auto-generated ZIP archives.
Developers that need some more info can still do a `git clone` or just look at this repo on GitHub.