### PR TITLE
Fix backwards incompatibility bug with ->addClass(null)

### DIFF
--- a/src/Traits/Tag.php
+++ b/src/Traits/Tag.php
@@ -545,10 +545,12 @@ abstract class Tag extends TreeObject
             $this->attributes['class'] = null;
         }
 
-        // Prevent adding a class twice
-        $classes = explode(' ', $this->attributes['class']);
-        if (!in_array($class, $classes, true)) {
-            $this->attributes['class'] = trim($this->attributes['class'].' '.$class);
+        if ($class !== null && $class !== '') {
+            // Prevent adding a class twice
+            $classes = explode(' ', $this->attributes['class']);
+            if (!in_array($class, $classes, true)) {
+                $this->attributes['class'] = trim($this->attributes['class'] . ' ' . $class);
+            }
         }
 
         return $this;

--- a/tests/Elements/ElementTest.php
+++ b/tests/Elements/ElementTest.php
@@ -15,4 +15,12 @@ class ElementTest extends HtmlObjectTestCase
 
         $this->assertHTML($matcher, $object);
     }
+
+    public function testIgnoreEmptyAddClassArgument()
+    {
+        $object = Element::p('foo')->addClass(null);
+        $output = $object->__toString();
+
+        $this->assertEquals("<p>foo</p>", $output);
+    }
 }


### PR DESCRIPTION
Hi @Anahkiasen,

Sorry for making more work for you today, thanks for releasing 1.4.3.

It ends up that 1.4.3 changes the behavior of `->addClass(null)`, which is causing headaches in 20+ Former tests.

This branch simply demonstrates the change -- feel free to merge a different fix if you like, or let me know if you don't consider this a regression and I will deal with it in former.

```php
# html-object 1.4.2:
Element::p('foo')->addClass(null)->__toString(); # <p>foo</p>

# html-object 1.4.3:
Element::p('foo')->addClass(null)->__toString(); # <p class="">foo</p>
```

The issue stems from the new strict `in_array` check in `Tag::addClass()`. It ends up this call is:

```php
# html-object 1.4.2:
in_array(null /* $class */, [""] /* $classes */); # true

# html-object 1.4.3:
in_array(null, [""], true); # false
```

To fix this, I simply checked if `$class` was `null` or `""` and avoided the is_array call in this case.