### PR TITLE
Fix removing class

### DIFF
--- a/src/Traits/Tag.php
+++ b/src/Traits/Tag.php
@@ -572,7 +572,7 @@ abstract class Tag extends TreeObject
         $thisClasses = explode(' ', Helpers::arrayGet($this->attributes, 'class'));
         foreach ($classes as $class) {
             $exists = array_search($class, $thisClasses, true);
-            if (!is_null($exists)) {
+            if ($exists !== false) {
                 unset($thisClasses[$exists]);
             }
         }

--- a/tests/TagTest.php
+++ b/tests/TagTest.php
@@ -214,6 +214,15 @@ class TagTest extends HtmlObjectTestCase
 
         $this->assertEquals('<p class="bar">foo</p>', $this->object->render());
     }
+        
+    public function testCannotRemoveWrongClasses()
+    {
+        $this->object->addClass('foo');
+        $this->object->addClass('bar');
+        $this->object->removeClass('unknow');
+
+        $this->assertEquals('<p class="foo bar">foo</p>', $this->object->render());
+    }
 
     public function testCanManuallyOpenElement()
     {


### PR DESCRIPTION
Hi @Anahkiasen,

This pull request fix a bug when using the [`HtmlObject\Traits\Tag::removeClass($classes)`](https://github.com/Anahkiasen/html-object/blob/aa670ecc06335a06a287f8abae5bf2df009c8f1f/src/Traits/Tag.php#L566) method.

Otherwise, when you try to remove a CSS class which isn't present, it'll remove a wrong CSS class, see the [testCanRemoveClasses](https://github.com/tortuetorche/html-object/blob/46dad477aa7728876db43f25cc5b48c976818076/tests/TagTest.php#L218) test for more info.

Because the [`array_search()`](https://www.php.net/manual/en/function.array-search.php) PHP function returns the key for `needle` if it is found in the array, `false` otherwise.
This `array_search()` function may return Boolean `false`, but may also return a non-Boolean value which evaluates to `false`.

So in the `HtmlObject\Traits\Tag::removeClass()` method of this package, we need to check if the [`$exists`](https://github.com/Anahkiasen/html-object/blob/aa670ecc06335a06a287f8abae5bf2df009c8f1f/src/Traits/Tag.php#L575) value is strictly not equals to `false` instead of using the `!is_null($exists)` check.

If this fix is merged and a new release is tagged, I'll update the [Former](https://github.com/formers/former) dependency to release the final version of [Former 5.0.0](https://github.com/formers/former/releases/tag/5.0.0-rc.1) 🤞

By the way, many thanks for all the work you have done on this package and Former 👍

Have a good day,
Tortue Torche