### PR TITLE
Fix "explode(): Passing null to parameter #2 ($string) of type string is deprecated"

### DIFF
--- a/src/Traits/Tag.php
+++ b/src/Traits/Tag.php
@@ -547,7 +547,7 @@ abstract class Tag extends TreeObject
 
         if ($class !== null && $class !== '') {
             // Prevent adding a class twice
-            $classes = explode(' ', $this->attributes['class']);
+            $classes = explode(' ', (string) $this->attributes['class']);
             if (!in_array($class, $classes, true)) {
                 $this->attributes['class'] = trim($this->attributes['class'] . ' ' . $class);
             }

--- a/src/Traits/TreeObject.php
+++ b/src/Traits/TreeObject.php
@@ -113,7 +113,7 @@ abstract class TreeObject
         }
 
         // Dot notation
-        $children = explode('.', $name);
+        $children = explode('.', (string) $name);
         if (count($children) === 1) {
             return Helpers::arrayGet($this->getChildren(), $children[0]);
         }


### PR DESCRIPTION
Since PHP 8.1, passing `null` as the second parameter of `explode()` raises this deprecation error:

```
Deprecated: explode(): Passing null to parameter #2 ($string) of type string is deprecated
```

Let's fix it.