### PR TITLE
Fix "mb_substr(): Passing null to parameter #1 ($string) of type string is deprecated"

### DIFF
--- a/src/Traits/Helpers.php
+++ b/src/Traits/Helpers.php
@@ -190,7 +190,7 @@ class Helpers
             }
 
             // Check for JSON attributes
-            if (in_array(mb_substr($value, 0, 1), array('{', '['), true)) {
+            if (in_array(mb_substr((string) $value, 0, 1), array('{', '['), true)) {
                 $html[] = $key."='".$value."'";
                 continue;
             }


### PR DESCRIPTION
As per the title :) Together with #35 this fixes all deprecations raised by the usage of this dependency in [Former](https://github.com/formers/former) too 🎉 